### PR TITLE
fix(examples): adapt to nushell API changes

### DIFF
--- a/p2-background/src/main.rs
+++ b/p2-background/src/main.rs
@@ -10,7 +10,7 @@ use nu_protocol::engine::{EngineState, Job, Stack, StateWorkingSet, ThreadJob};
 use nu_protocol::{Id, PipelineData, Signals, Span, Value};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc, Arc,
+    Arc,
 };
 use std::time::Duration;
 
@@ -62,14 +62,11 @@ fn run_script_in_background(
     code_snippet: &str,
 ) -> Result<(Id<nu_protocol::marker::Job>, std::thread::JoinHandle<()>), Box<dyn std::error::Error>>
 {
-    // Create a channel for the thread job
-    let (sender, _receiver) = mpsc::channel();
-
     // Create a new signals object for this job
     let signals = Signals::empty();
 
     // Create a thread job
-    let job = ThreadJob::new(signals.clone(), Some("Script Job".to_string()), sender);
+    let job = ThreadJob::new(signals.clone(), Some("Script Job".to_string()));
 
     // Add the job to the engine's job table
     let job_id = {
@@ -86,7 +83,7 @@ fn run_script_in_background(
         std::thread::spawn(move || {
             // Set the current job context to enable background job tracking in this thread
             let mut thread_local_state = (*engine_state).clone();
-            thread_local_state.current_job.background_thread_job = Some(job);
+            thread_local_state.current_thread_job = Some(job);
 
             let mut stack = Stack::new();
 

--- a/p3-the-works/src/main.rs
+++ b/p3-the-works/src/main.rs
@@ -144,7 +144,7 @@ fn print_result(value: Value, job_number: usize) {
 /// Handles job tracking, execution and cleanup through Nushell's job system.
 fn process_job(engine_state: &EngineState, closure: &Closure, line: &str, job_number: usize) {
     // Create a thread job for this evaluation
-    let (sender, _receiver) = std::sync::mpsc::channel();
+
 
     // Get the signals from the engine state to ensure we're using the same
     // interrupt flag that's connected to Ctrl+C handling
@@ -152,7 +152,7 @@ fn process_job(engine_state: &EngineState, closure: &Closure, line: &str, job_nu
 
     // Create the job
     let job =
-        nu_protocol::engine::ThreadJob::new(signals, Some(format!("Job {}", job_number)), sender);
+        nu_protocol::engine::ThreadJob::new(signals, Some(format!("Job {}", job_number)));
 
     // Add the job to the engine's job table
     let job_id = {
@@ -162,7 +162,7 @@ fn process_job(engine_state: &EngineState, closure: &Closure, line: &str, job_nu
 
     // Create a clone of the engine state with this job as the current job
     let mut local_engine_state = engine_state.clone();
-    local_engine_state.current_job.background_thread_job = Some(job);
+    local_engine_state.current_thread_job = Some(job);
 
     // Process with the local engine state that has the job context
     let mut stack = Stack::new();


### PR DESCRIPTION
## Summary
- update examples for renamed `current_thread_job`
- remove unused sender argument when creating `ThreadJob`

## Testing
- `cargo test`