### PR TITLE
feat(p1-basic): stream pipeline output

### DIFF
--- a/p1-basic/README.md
+++ b/p1-basic/README.md
@@ -45,13 +45,21 @@ engine.merge_delta(ws.render())?;
 
 // 4. Run the block and print the result
 let mut stack = nu_protocol::engine::Stack::new();
+let mut stack = stack.push_redirection(
+    Some(nu_protocol::engine::Redirection::Pipe(
+        nu_protocol::OutDest::PipeSeparate,
+    )),
+    None,
+);
 let out = nu_engine::eval_block_with_early_return::<nu_protocol::debugger::WithoutDebug>(
     &engine,
     &mut stack,
     &block,
     nu_protocol::PipelineData::empty(),
 )?;
-println!("{:?}", out.into_value(nu_protocol::Span::unknown())?);
+for value in out {
+    println!("{:?}", value);
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- set stack redirection when running blocks
- iterate over `PipelineData` instead of converting with `into_value`
- update docs to show streaming approach

## Testing
- `./scripts/check.sh`